### PR TITLE
Allows deployment of monorepos

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
 const { Server } = require('http');
 const { Bridge } = require('./bridge.js');
 const fs = require('fs');
+const path = require('path');
 
 var walkSync = function(dir, filelist) {
                 files = fs.readdirSync(dir);
@@ -63,6 +64,14 @@ try {
   }
 
   process.chdir("./user")
+
+console.log('dirname', __dirname)
+console.log('current dir', process.cwd())
+console.log('require path is', "${path.join(
+    '.',
+    basePath,
+    'server/server.js'
+  )}");
 
 let ajfiles = []
 walkSync('.', ajfiles)

--- a/index.js
+++ b/index.js
@@ -68,17 +68,17 @@ try {
 console.log('dirname', __dirname)
 console.log('current dir', process.cwd())
 console.log('require path is', "${path.join(
-    '.',
+    process.cwd(),
     basePath,
     'server/server.js'
   )}");
 
 let ajfiles = []
-walkSync('.', ajfiles)
-console.log('diry', '.', ajfiles)
+walkSync(process.cwd(), ajfiles)
+console.log('diry', process.cwd(), ajfiles)
 
   listener = require("${path.join(
-    '.',
+    process.cwd(),
     basePath,
     'server/server.js'
   )}");

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
-  console.log('desired entrypoint', path.join(
+  console.log('aaaa- desired entrypoint', path.join(
     'user',
     basePath,
     'server/server.js'

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ exports.config = {
 
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
+  const basePath = path.dirname(entrypoint)
   const userFiles = rename(files, name => path.join('user', name))
 
   const userPath = path.join(workPath, 'user');
@@ -48,7 +49,6 @@ try {
 
   process.chdir("./user")
 
-  const basePath = path.dirname(entrypoint)
   listener = require("./${path.join(
     'user',
     basePath,

--- a/index.js
+++ b/index.js
@@ -39,20 +39,6 @@ const { Bridge } = require('./bridge.js');
 const fs = require('fs');
 const path = require('path');
 
-var walkSync = function(dir, filelist) {
-                files = fs.readdirSync(dir);
-            filelist = filelist || [];
-            files.forEach(function(file) {
-                if (fs.statSync(path.join(dir, file)).isDirectory()) {
-                    filelist = walkSync(path.join(dir, file), filelist);
-                }
-                else {
-                    filelist.push(path.join(dir, file));
-                }
-            });
-            return filelist;
-        };
-
 const bridge = new Bridge();
 bridge.port = 3000;
 let listener;
@@ -66,17 +52,15 @@ try {
   const rootDir = path.join(
     process.cwd(),
     'user',
-    "${basePath}")
+    "${basePath}",
+    '..',
+    '..'
+  )
   process.chdir(rootDir)
-
-console.log('given rootdir', rootDir)
-console.log('contents of local dir is', fs.readdirSync('.'))
-console.log('absolute path of local dir is', __dirname)
-console.log('cwd', process.cwd())
 
   listener = require(path.join(
     rootDir,
-    'server/server.js'
+    '__sapper__/build/server/server.js'
   ));
 
   if (listener.default) {

--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ exports.build = async ({ files, entrypoint, workPath }) => {
     'server/server.js'
   ))
   const userFiles = rename(files, name => path.join('user', name))
+  console.log('f', files)
+  console.log('u', userFiles)
+  console.log('upath', workPath)
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);

--- a/index.js
+++ b/index.js
@@ -39,8 +39,6 @@ const { Bridge } = require('./bridge.js');
 const fs = require('fs');
 
 var walkSync = function(dir, filelist) {
-            var path = path || require('path');
-            var fs = fs || require('fs'),
                 files = fs.readdirSync(dir);
             filelist = filelist || [];
             files.forEach(function(file) {
@@ -68,10 +66,10 @@ try {
 
 let ajfiles = []
 walkSync('.', ajfiles)
-console.log('diry', __dirname, ajfiles)
+console.log('diry', '.', ajfiles)
 
   listener = require("${path.join(
-    __dirname,
+    '.',
     basePath,
     'server/server.js'
   )}");

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
-  const userFiles = rename(files, name => path.join(user, basePath, name))
+  const userFiles = rename(files, name => path.join('user', basePath, name))
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);

--- a/index.js
+++ b/index.js
@@ -63,20 +63,11 @@ try {
     process.env.NODE_ENV = 'production';
   }
 
-  process.chdir("./user")
-
-console.log('dirname', __dirname)
-console.log('current dir', process.cwd())
-console.log('require path is', "${path.join(
+  const rootDir = path.join(
     process.cwd(),
     'user',
-    basePath,
-    'server/server.js'
-  )}");
-
-let ajfiles = []
-walkSync(process.cwd(), ajfiles)
-console.log('diry', process.cwd(), ajfiles)
+    basePath)
+  process.chdir(rootDir)
 
   listener = require("${path.join(
     process.cwd(),

--- a/index.js
+++ b/index.js
@@ -38,6 +38,22 @@ const { Server } = require('http');
 const { Bridge } = require('./bridge.js');
 const fs = require('fs');
 
+var walkSync = function(dir, filelist) {
+            var path = path || require('path');
+            var fs = fs || require('fs'),
+                files = fs.readdirSync(dir);
+            filelist = filelist || [];
+            files.forEach(function(file) {
+                if (fs.statSync(path.join(dir, file)).isDirectory()) {
+                    filelist = walkSync(path.join(dir, file), filelist);
+                }
+                else {
+                    filelist.push(path.join(dir, file));
+                }
+            });
+            return filelist;
+        };
+
 const bridge = new Bridge();
 bridge.port = 3000;
 let listener;
@@ -49,6 +65,10 @@ try {
   }
 
   process.chdir("./user")
+
+let ajfiles = []
+walkSync('.', ajfiles)
+console.log('diry', __dirname, ajfiles)
 
   listener = require("./${path.join(
     basePath,

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
-  const userFiles = rename(files, name => path.join('user', basePath, name))
+  const userFiles = rename(files, name => path.join(basePath, name))
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);
@@ -54,7 +54,6 @@ try {
 console.log('user is', fs.readdirSync('./user'))
 
   listener = require("./${path.join(
-    'user',
     basePath,
     'server/server.js'
   )}");

--- a/index.js
+++ b/index.js
@@ -24,14 +24,6 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
-  console.log('aaaa- desired entrypoint', path.join(
-    'user',
-    basePath,
-    'server/server.js'
-  ))
-  console.log('f', files)
-  console.log('u', userFiles)
-  console.log('upath', workPath)
   const userFiles = rename(files, name => path.join('user', basePath, name))
   const userPath = path.join(workPath, 'user');
   

--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ let ajfiles = []
 walkSync('.', ajfiles)
 console.log('diry', __dirname, ajfiles)
 
-  listener = require("./${path.join(
+  listener = require("${path.join(
+    __dirname,
     basePath,
     'server/server.js'
   )}");

--- a/index.js
+++ b/index.js
@@ -29,10 +29,10 @@ exports.build = async ({ files, entrypoint, workPath }) => {
     basePath,
     'server/server.js'
   ))
-  const userFiles = rename(files, name => path.join('user', name))
   console.log('f', files)
   console.log('u', userFiles)
   console.log('upath', workPath)
+  const userFiles = rename(files, name => path.join('user', name)
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);

--- a/index.js
+++ b/index.js
@@ -74,10 +74,10 @@ console.log('contents of local dir is', fs.readdirSync('.'))
 console.log('absolute path of local dir is', __dirname)
 console.log('cwd', process.cwd())
 
-  listener = require("${path.join(
+  listener = require(path.join(
     rootDir,
     'server/server.js'
-  )}");
+  ));
 
   if (listener.default) {
     listener = listener.default;

--- a/index.js
+++ b/index.js
@@ -24,11 +24,11 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
-  console.log('desired entrypoint', "./${path.join(
+  console.log('desired entrypoint', path.join(
     'user',
     basePath,
     'server/server.js'
-  )}")
+  ))
   const userFiles = rename(files, name => path.join('user', name))
 
   const userPath = path.join(workPath, 'user');

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   console.log('f', files)
   console.log('u', userFiles)
   console.log('upath', workPath)
-  const userFiles = rename(files, name => path.join('user', name)
+  const userFiles = rename(files, name => path.join('user', basePath, name)
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);

--- a/index.js
+++ b/index.js
@@ -66,13 +66,16 @@ try {
   const rootDir = path.join(
     process.cwd(),
     'user',
-    basePath)
+    "${basePath}")
   process.chdir(rootDir)
 
+console.log('given rootdir', rootDir)
+console.log('contents of local dir is', fs.readdirSync('.'))
+console.log('absolute path of local dir is', __dirname)
+console.log('cwd', process.cwd())
+
   listener = require("${path.join(
-    process.cwd(),
-    'user',
-    basePath,
+    rootDir,
     'server/server.js'
   )}");
 

--- a/index.js
+++ b/index.js
@@ -32,9 +32,6 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   const userFiles = rename(files, name => path.join('user', name))
   const userPath = path.join(workPath, 'user');
   
-  console.log('workpath', workpath);
-  console.log(userFiles);
-  console.log(userPath);
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);
 
   // Get launcher

--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
+  console.log('desired entrypoint', "./${path.join(
+    'user',
+    basePath,
+    'server/server.js'
+  )}")
   const userFiles = rename(files, name => path.join('user', name))
 
   const userPath = path.join(workPath, 'user');
@@ -54,7 +59,6 @@ try {
     basePath,
     'server/server.js'
   )}");
-console.log('listener is', listener);
 
   if (listener.default) {
     listener = listener.default;

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ try {
     basePath,
     'server/server.js'
   )}");
+console.log('listener is', listener);
 
   if (listener.default) {
     listener = listener.default;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ exports.config = {
 }
 
 exports.build = async ({ files, entrypoint, workPath }) => {
-  console.log('entry point', entrypoint)
   // move all user code to 'user' subdirectory
   const userFiles = rename(files, name => path.join('user', name))
 
@@ -49,9 +48,11 @@ try {
 
   process.chdir("./user")
 
+  const basePath = path.dirname(entrypoint)
   listener = require("./${path.join(
     'user',
-    '__sapper__/build/server/server.js'
+    basePath,
+    'server/server.js'
   )}");
 
   if (listener.default) {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
         `
 const { Server } = require('http');
 const { Bridge } = require('./bridge.js');
+const fs = require('fs');
 
 const bridge = new Bridge();
 bridge.port = 3000;

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   console.log('f', files)
   console.log('u', userFiles)
   console.log('upath', workPath)
-  const userFiles = rename(files, name => path.join('user', basePath, name)
+  const userFiles = rename(files, name => path.join('user', basePath, name))
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);

--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ try {
 
   process.chdir("./user")
 
+  console.log('curr is', fs.readdirSync('.'))
+console.log('user is', fs.readdirSync('./user'))
+
   listener = require("./${path.join(
     'user',
     basePath,

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
-  const userFiles = rename(files, name => path.join('user', basePath, name))
+  const userFiles = rename(files, name => path.join('user', name))
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ console.log('dirname', __dirname)
 console.log('current dir', process.cwd())
 console.log('require path is', "${path.join(
     process.cwd(),
+    'user',
     basePath,
     'server/server.js'
   )}");
@@ -79,6 +80,7 @@ console.log('diry', process.cwd(), ajfiles)
 
   listener = require("${path.join(
     process.cwd(),
+    'user',
     basePath,
     'server/server.js'
   )}");

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.config = {
 exports.build = async ({ files, entrypoint, workPath }) => {
   // move all user code to 'user' subdirectory
   const basePath = path.dirname(entrypoint)
-  const userFiles = rename(files, name => path.join(basePath, name))
+  const userFiles = rename(files, name => path.join(user, basePath, name))
   const userPath = path.join(workPath, 'user');
   
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);
@@ -49,9 +49,6 @@ try {
   }
 
   process.chdir("./user")
-
-  console.log('curr is', fs.readdirSync('.'))
-console.log('user is', fs.readdirSync('./user'))
 
   listener = require("./${path.join(
     basePath,

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ exports.build = async ({ files, entrypoint, workPath }) => {
   const userFiles = rename(files, name => path.join('user', name))
   const userPath = path.join(workPath, 'user');
   
-  console.log('workpath');
+  console.log('workpath', workpath);
   console.log(userFiles);
   console.log(userPath);
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);

--- a/index.js
+++ b/index.js
@@ -30,8 +30,11 @@ exports.build = async ({ files, entrypoint, workPath }) => {
     'server/server.js'
   ))
   const userFiles = rename(files, name => path.join('user', name))
-
   const userPath = path.join(workPath, 'user');
+  
+  console.log('workpath');
+  console.log(userFiles);
+  console.log(userPath);
   //await spawnAsync('npm', ['install', '--only=prod'], userPath);
 
   // Get launcher

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ exports.config = {
 }
 
 exports.build = async ({ files, entrypoint, workPath }) => {
+  console.log('entry point', entrypoint)
   // move all user code to 'user' subdirectory
   const userFiles = rename(files, name => path.join('user', name))
 


### PR DESCRIPTION
One common usecase for now is a monorepo, made up from a variety of apps, API, frontend, various functions, etc.

This PR allows a sapper app to be run as part of a monorepo by not relying on the application sitting at the root of the deployed directory.

It also removes some indirection from the generated JS.

You might want to squash commit this as I lost the will to live somewhere in the middle.

Fixes #1