### PR TITLE
Serves service-worker.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,12 @@ exports.build = async ({
       headers: { 'cache-control': 'public,max-age=31536000,immutable' },
       continue: true
     },
-    { handle: 'filesystem' },
     {
       src: '/service-worker.js',
-      headers: { 'cache-control': 'no-store' },
+      headers: { 'cache-control': 'public,max-age=0,must-revalidate' },
       continue: true
     },
+    { handle: 'filesystem' },
     { src: '/(.*)', dest: '/' }
   ]
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ exports.build = async ({
 
   const output = {
     ...serve(staticFiles, 'static/', ''),
+    ...serve(applicationFiles, '__sapper__/build/service-worker.js', ''),
     ...serve(applicationFiles, '__sapper__/build/client', 'client'),
     index: lambda
   }
@@ -61,6 +62,11 @@ exports.build = async ({
       continue: true
     },
     { handle: 'filesystem' },
+    {
+      src: '/service-worker.js',
+      headers: { 'cache-control': 'no-store' },
+      continue: true
+    },
     { src: '/(.*)', dest: '/' }
   ]
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ exports.build = async ({
 
   const output = {
     ...serve(staticFiles, 'static/', ''),
-    ...serve(applicationFiles, '__sapper__/build/service-worker.js', ''),
+    ...serve(applicationFiles, '__sapper__/build/service-worker.js', 'service-worker.js'),
     ...serve(applicationFiles, '__sapper__/build/client', 'client'),
     index: lambda
   }


### PR DESCRIPTION
This copies and serves the sapper service-worker. It also adds some special cache control which is impossible to detect in Chrome due to their intervention in service worker caching, but should work for other browsers, causing the service-worker.js file never to be cached. Fixes https://github.com/thgh/now-sapper/issues/12