### PR TITLE
Fix node version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,15 @@ Example `now.json`
 
 ### Changing the node runtime
 
-You can change the AWS lambda runtime from the default node 8
+You can change the Node.js version with the engines field.
 
-Example `now.json`
+Example `package.json`
 ```json
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "now-sapper",
-      "config": {
-        "runtime": "nodejs10.x"
-      }
-    }
-  ]
+  "engines": {
+    "node": "12.x"
+  }
 }
-
 ```
 
 ## Preparation

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Example `package.json`
 
 ## Preparation
 
-Your Sapper project must be adapted to work with Zeit Now v2, see https://github.com/thgh/sapper-template/commit/220307c800525633063df3e3373bc76d0e62cd86
+Your Sapper project must be adapted to work with ZEIT Now 2.0, see https://github.com/thgh/sapper-template/commit/220307c800525633063df3e3373bc76d0e62cd86
 
 For Express, the instance must be exported in `src/server.js`
 ```js

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,6 @@
 exports.getConfig = function getConfig (rawConfig) {
   return {
     build: true,
-    runtime: 'nodejs8.10',
     ...rawConfig
   }
 }

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const os = require('os') 
+const os = require('os')
 const path = require('path')
 const fs = require('fs-extra')
 
@@ -11,9 +11,9 @@ const {
   runPackageJsonScript,
 } = require('@now/build-utils')
 
-exports.npmBuild = async function npmBuild (config, entrypointDir, meta) {
+exports.npmBuild = async function npmBuild (config, entrypointDir, spawnOpts, meta) {
   if (config.build) {
-    await runNpmInstall(entrypointDir, ['--prefer-offline'], {}, meta)
+    await runNpmInstall(entrypointDir, ['--prefer-offline'], spawnOpts, meta)
     await runPackageJsonScript(
       entrypointDir,
       'build',
@@ -26,10 +26,10 @@ exports.npmBuild = async function npmBuild (config, entrypointDir, meta) {
       path.join(entrypointDir, 'package.json'),
       path.join(tempDir, 'package.json')
     )
-    
+
     const originalDir = process.cwd()
     process.chdir(tempDir)
-    await runNpmInstall(tempDir, ['--prefer-offline', '--production'], {}, meta)
+    await runNpmInstall(tempDir, ['--prefer-offline', '--production'], spawnOpts, meta)
     process.chdir(originalDir)
 
     return globAndPrefix(tempDir, 'node_modules')

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -17,7 +17,7 @@ exports.npmBuild = async function npmBuild (config, entrypointDir, spawnOpts, me
     await runPackageJsonScript(
       entrypointDir,
       'build',
-      {}
+      spawnOpts
     )
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'now-'))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "now-sapper",
   "version": "0.36.0",
   "license": "MIT",
-  "description": "ZEIT Now v2.0 builder for Sapper",
+  "description": "ZEIT Now 2.0 builder for Sapper",
   "main": "index.js",
   "files": [
     "index.js",


### PR DESCRIPTION
This fixes `now-sapper` to act more like `@now/node` and use package.json to select the Node.js version.

Related to #11 