### PR TITLE
Enable deployment on 10.x and 12.x engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ exports.build = async ({
   const config = getConfig(rawConfig)
   const prodDependencies = await npmBuild(config, entrypointDir)
 
-  const launcherFiles = getLauncherFiles(mountpoint)
+  const launcherFiles = getLauncherFiles()
   const staticFiles = await globAndPrefix(entrypointDir, 'static')
   const applicationFiles = await globAndPrefix(entrypointDir, '__sapper__')
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -12,10 +12,10 @@ try {
     process.env.NODE_ENV = 'production'
   }
 
-  process.chdir('{mountpoint}')
+  process.chdir(__dirname)
 
   listener = require(path.join(
-    '{mountpoint}',
+    __dirname,
     '__sapper__/build/server/server.js'
   ))
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,11 +11,10 @@ const {
 
 const bridge = require('@now/node-bridge')
 
-exports.getLauncherFiles = function getLauncherFiles (mountpoint) {
+exports.getLauncherFiles = function getLauncherFiles () {
   const launcherPath = path.join(__dirname, 'launcher.js')
-  const compiled = fs.readFileSync(launcherPath, { encoding: 'utf-8' }).replace(new RegExp('{mountpoint}', 'g'), mountpoint)
   return {
-    'launcher.js': new FileBlob({ data: compiled }),
+    'launcher.js': new FileFsRef({ fsPath: launcherPath }),
     'bridge.js': new FileFsRef({ fsPath: bridge })
   }
 }


### PR DESCRIPTION
Amazon decided to do its upgrade and break everything that existed previously, and this appears to be the fix. I'm not going to lie. I have no idea why it works.