### PR TITLE
Fix missing await in function `npmBuild`

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -35,6 +35,6 @@ exports.npmBuild = async function npmBuild(
     )
     process.chdir(originalDir)
 
-    return globAndPrefix(tempDir, 'node_modules')
+    return await globAndPrefix(tempDir, 'node_modules')
   }
 }


### PR DESCRIPTION
Function `npmBuild` was returning a Promise, so in the file [index.js](https://github.com/thgh/vercel-sapper/blob/vercel/index.js) the variable `prodDependencies` when destructuring it acted as an empty object

Possibly solves #42